### PR TITLE
public url

### DIFF
--- a/backend/model/nyu_custom_model_marc21.rb
+++ b/backend/model/nyu_custom_model_marc21.rb
@@ -670,13 +670,16 @@ class MARCModel < ASpaceExport::ExportModel
   # use instead of ead loc
   def finding_aid_loc(publish, uri, title, id_0)
     if publish
+      return unless uri && !uri.empty?
+
+      public_url = URI.join("https://scua.uoregon.edu", uri).to_s
       df('555', ' ', ' ').with_sfs(
         ['a', "Finding aid available online:"],
-        ['u', "#{AppConfig[:public_url]}#{uri}"]
+        ['u', public_url]
       )
       df('856', '4', '2').with_sfs(
         ['z', "Connect to the online finding aid for this collection"],
-        ['u', "#{AppConfig[:public_url]}#{uri}"]
+        ['u', public_url]
       )
     else
       df('856', '4', '2').with_sfs(


### PR DESCRIPTION
Used AppConfig[:public_url] to build the full url for the resource for tags 856 and 555, however we get a url using localhost, and not the public-facing url. After requesting advice, am hardcoding the domain into the method. if it turns out we need this in more than one place in the future, can add a config or something.